### PR TITLE
observer pattern working with comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="index.js"></script>
+  <script src="index.js" ></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,14 +1,20 @@
-import { Home } from "./store";
-import { StateSubject } from "./lib/StateSubject";
-import { NavigatableObserver } from "./lib/NavigatableObserver";
+import * as state from "./store";
 import Navigo from "navigo";
 import { capitalize } from "lodash";
-import { BlogObserver } from "./lib/BlogObserver";
-import { FormObserver } from "./lib/FormObserver";
+import {
+  StateSubject,
+  NavigatableObserver,
+  BlogObserver,
+  FormObserver
+} from "./lib";
+// import { StateSubject } from "./lib/StateSubject";
+// import { NavigatableObserver } from "./lib/NavigatableObserver";
+// import { BlogObserver } from "./lib/BlogObserver";
+// import { FormObserver } from "./lib/FormObserver";
 
 const router = new Navigo(window.location.origin);
 
-const appState = new StateSubject(Home);
+const appState = new StateSubject(state.Home, state);
 // create a page set for the website, as state changes all of these
 // will update via the notification mechanism of the Subject/Observer
 // design pattern

--- a/index.js
+++ b/index.js
@@ -1,24 +1,30 @@
-import * as state from "./store";
 import Navigo from "navigo";
 import { capitalize } from "lodash";
+import * as state from "./store";
 import {
   StateSubject,
   NavigatableObserver,
   BlogObserver,
   FormObserver
 } from "./lib";
-// import { StateSubject } from "./lib/StateSubject";
-// import { NavigatableObserver } from "./lib/NavigatableObserver";
-// import { BlogObserver } from "./lib/BlogObserver";
-// import { FormObserver } from "./lib/FormObserver";
 
 const router = new Navigo(window.location.origin);
 
-const appState = new StateSubject(state.Home, state);
+const appState = new StateSubject(state.Home, state, router);
 // create a page set for the website, as state changes all of these
 // will update via the notification mechanism of the Subject/Observer
 // design pattern
+// router
+//   .on({
+//     ":page": params =>
+//       appState.setState(appState.stateStore[capitalize(params.page)]),
+//     "/": () => appState.setState(appState.stateStore.Home)
+//   })
+//   .resolve();
+
 const pages = [];
+// pages.push(new StateObserver(appState, appState.stateStore.Bio));
+// pages.push(new StateObserver(appState, appState.stateStore.Home));
 pages.push(new NavigatableObserver(appState, appState.stateStore.Bio)); //state.Bio));
 pages.push(new FormObserver(appState, appState.stateStore.Form)); // state.Form));
 pages.push(new BlogObserver(appState, appState.stateStore.Blog)); // state.Blog));

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ pages.push(new BlogObserver(appState, appState.stateStore.Blog));
 pages.push(new NavigatableObserver(appState, appState.stateStore.Gallery));
 pages.push(new NavigatableObserver(appState, appState.stateStore.Home));
 
-//when state changes, we use a clear "setState" instead of the abiguois "render"
+//when state changes, we use a clear "setState" instead of the ambiguous "render"
 router
   .on({
     ":page": params =>

--- a/index.js
+++ b/index.js
@@ -1,24 +1,29 @@
-import * as state from "./store";
+import { Home } from "./store";
 import { StateSubject } from "./lib/StateSubject";
 import { NavigatableObserver } from "./lib/NavigatableObserver";
 import Navigo from "navigo";
 import { capitalize } from "lodash";
 import { BlogObserver } from "./lib/BlogObserver";
+import { FormObserver } from "./lib/FormObserver";
 
 const router = new Navigo(window.location.origin);
 
-const appState = new StateSubject(state.Home);
+const appState = new StateSubject(Home);
+// create a page set for the website, as state changes all of these
+// will update via the notification mechanism of the Subject/Observer
+// design pattern
 const pages = [];
-pages.push(new NavigatableObserver(appState, state.Bio));
-pages.push(new NavigatableObserver(appState, state.Form));
-pages.push(new BlogObserver(appState, state.Blog));
-pages.push(new NavigatableObserver(appState, state.Gallery));
-pages.push(new NavigatableObserver(appState, state.Home));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Bio)); //state.Bio));
+pages.push(new FormObserver(appState, appState.stateStore.Form)); // state.Form));
+pages.push(new BlogObserver(appState, appState.stateStore.Blog)); // state.Blog));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Gallery)); // state.Gallery));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Home)); // state.Home));
 
 //when state changes, we use a clear "setState" instead of the abiguois "render"
 router
   .on({
-    ":page": params => appState.setState(state[capitalize(params.page)]),
-    "/": () => appState.setState(state.Home)
+    ":page": params =>
+      appState.setState(appState.stateStore[capitalize(params.page)]),
+    "/": () => appState.setState(appState.stateStore.Home)
   })
   .resolve();

--- a/index.js
+++ b/index.js
@@ -11,25 +11,13 @@ import {
 const router = new Navigo(window.location.origin);
 
 const appState = new StateSubject(state.Home, state, router);
-// create a page set for the website, as state changes all of these
-// will update via the notification mechanism of the Subject/Observer
-// design pattern
-// router
-//   .on({
-//     ":page": params =>
-//       appState.setState(appState.stateStore[capitalize(params.page)]),
-//     "/": () => appState.setState(appState.stateStore.Home)
-//   })
-//   .resolve();
 
 const pages = [];
-// pages.push(new StateObserver(appState, appState.stateStore.Bio));
-// pages.push(new StateObserver(appState, appState.stateStore.Home));
-pages.push(new NavigatableObserver(appState, appState.stateStore.Bio)); //state.Bio));
-pages.push(new FormObserver(appState, appState.stateStore.Form)); // state.Form));
-pages.push(new BlogObserver(appState, appState.stateStore.Blog)); // state.Blog));
-pages.push(new NavigatableObserver(appState, appState.stateStore.Gallery)); // state.Gallery));
-pages.push(new NavigatableObserver(appState, appState.stateStore.Home)); // state.Home));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Bio));
+pages.push(new FormObserver(appState, appState.stateStore.Form));
+pages.push(new BlogObserver(appState, appState.stateStore.Blog));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Gallery));
+pages.push(new NavigatableObserver(appState, appState.stateStore.Home));
 
 //when state changes, we use a clear "setState" instead of the abiguois "render"
 router

--- a/lib/ApiNavigateableObserver.js
+++ b/lib/ApiNavigateableObserver.js
@@ -10,22 +10,22 @@ export class ApiNavigateableObserver extends NavigatableObserver {
   }
 
   // since we have 2 sublasses we need to avoid calling update twice and simple overrride
-  // update(state) {
-  //   // super.update(state);
-  //   if (this.active == true) {
-  //     this.getRequest();
-  //   }
-  // }
-
   update(state) {
-    if (state.view == this.stateContext.view) {
-      this.active = true;
+    super.update(state);
+    if (this.active == true) {
       this.getRequest();
-      this.render();
-    } else {
-      this.active = false;
     }
   }
+
+  // update(state) {
+  //   if (state.view == this.stateContext.view) {
+  //     this.active = true;
+  //     this.getRequest();
+  //     this.render();
+  //   } else {
+  //     this.active = false;
+  //   }
+  // }
 
   getRequest() {
     axios

--- a/lib/ApiNavigateableObserver.js
+++ b/lib/ApiNavigateableObserver.js
@@ -1,7 +1,12 @@
-"use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
 import axios from "axios";
 
+/**
+ * ApiNavigateableObserver is a generic base class that currently supports only one
+ * get method to one url, and one callback defined by instantiation. The get request
+ * is automatically called when an update is triggered (this may not be the behavior you
+ * want).
+ */
 export class ApiNavigateableObserver extends NavigatableObserver {
   constructor(subject, state, url, callback) {
     super(subject, state);
@@ -9,7 +14,7 @@ export class ApiNavigateableObserver extends NavigatableObserver {
     this.callback = callback;
   }
 
-  // since we have 2 sublasses we need to avoid calling update twice and simple overrride
+  // since we have 2 sublasses we need to avoid calling update twice and simple override
   update(state) {
     if (state.view == this.stateContext.view) {
       this.active = true;
@@ -20,6 +25,10 @@ export class ApiNavigateableObserver extends NavigatableObserver {
     }
   }
 
+  /**
+   * getRequest uses axios to make a "get" request to the desiganted api url and call the callback
+   * when the response is recieved, returning data to the appropriate recipoient.
+   */
   getRequest() {
     axios
       .get(this.url)

--- a/lib/ApiNavigateableObserver.js
+++ b/lib/ApiNavigateableObserver.js
@@ -1,3 +1,4 @@
+"use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
 import axios from "axios";
 
@@ -8,10 +9,21 @@ export class ApiNavigateableObserver extends NavigatableObserver {
     this.callback = callback;
   }
 
-  notify(state) {
-    super.notify(state);
-    if (this.active == true) {
+  // since we have 2 sublasses we need to avoid calling update twice and simple overrride
+  // update(state) {
+  //   // super.update(state);
+  //   if (this.active == true) {
+  //     this.getRequest();
+  //   }
+  // }
+
+  update(state) {
+    if (state.view == this.stateContext.view) {
+      this.active = true;
       this.getRequest();
+      this.render();
+    } else {
+      this.active = false;
     }
   }
 

--- a/lib/ApiNavigateableObserver.js
+++ b/lib/ApiNavigateableObserver.js
@@ -10,13 +10,6 @@ export class ApiNavigateableObserver extends NavigatableObserver {
   }
 
   // since we have 2 sublasses we need to avoid calling update twice and simple overrride
-  // update(state) {
-  //   super.update(state);
-  //   if (this.active == true) {
-  //     this.getRequest();
-  //   }
-  // }
-
   update(state) {
     if (state.view == this.stateContext.view) {
       this.active = true;

--- a/lib/ApiNavigateableObserver.js
+++ b/lib/ApiNavigateableObserver.js
@@ -10,22 +10,22 @@ export class ApiNavigateableObserver extends NavigatableObserver {
   }
 
   // since we have 2 sublasses we need to avoid calling update twice and simple overrride
-  update(state) {
-    super.update(state);
-    if (this.active == true) {
-      this.getRequest();
-    }
-  }
-
   // update(state) {
-  //   if (state.view == this.stateContext.view) {
-  //     this.active = true;
+  //   super.update(state);
+  //   if (this.active == true) {
   //     this.getRequest();
-  //     this.render();
-  //   } else {
-  //     this.active = false;
   //   }
   // }
+
+  update(state) {
+    if (state.view == this.stateContext.view) {
+      this.active = true;
+      this.getRequest();
+      this.render();
+    } else {
+      this.active = false;
+    }
+  }
 
   getRequest() {
     axios

--- a/lib/BlogObserver.js
+++ b/lib/BlogObserver.js
@@ -19,10 +19,6 @@ export class BlogObserver extends ApiNavigateableObserver {
     console.log("response.data", response.data);
     response.data.forEach(post => {
       this.subject.stateStore.Blog.posts.push(post);
-      //stateStore.Blog.posts.push(post);
-      //this.subject.stateStore = stateStore;
     });
-    // lets just "refresh", router params shouldn't matter
-    this.subject.refreshStateView();
   }
 }

--- a/lib/BlogObserver.js
+++ b/lib/BlogObserver.js
@@ -1,5 +1,3 @@
-//import * as stateStore from "../store";
-"use strict";
 import { ApiNavigateableObserver } from "./ApiNavigateableObserver";
 
 export class BlogObserver extends ApiNavigateableObserver {

--- a/lib/BlogObserver.js
+++ b/lib/BlogObserver.js
@@ -1,5 +1,13 @@
 import { ApiNavigateableObserver } from "./ApiNavigateableObserver";
 
+/**
+ * BlogObserver manages the updates to the Blog page. This inherits from the
+ * ApiNavigateableObserver class and sets the url to our blog API url.
+ * We create a custom callback to be passed to the ApiNavigateableObserver
+ * and called when the response is recieved. This is just another example,
+ * currently the functionality is limited to one "get" and providing
+ * "get","post", "put", "delete" actions would be more appropriate.
+ */
 export class BlogObserver extends ApiNavigateableObserver {
   constructor(subject, stateContext) {
     // can't use "this" in super call, so default to null

--- a/lib/BlogObserver.js
+++ b/lib/BlogObserver.js
@@ -1,4 +1,5 @@
-import * as storeState from "../store";
+//import * as stateStore from "../store";
+"use strict";
 import { ApiNavigateableObserver } from "./ApiNavigateableObserver";
 
 export class BlogObserver extends ApiNavigateableObserver {
@@ -17,7 +18,9 @@ export class BlogObserver extends ApiNavigateableObserver {
   processRequestResponse(response) {
     console.log("response.data", response.data);
     response.data.forEach(post => {
-      storeState.Blog.posts.push(post);
+      this.subject.stateStore.Blog.posts.push(post);
+      //stateStore.Blog.posts.push(post);
+      //this.subject.stateStore = stateStore;
     });
     // lets just "refresh", router params shouldn't matter
     this.subject.refreshStateView();

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,4 +1,7 @@
+"use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
+//import * as stateStore from "../store";
+import { Header, Main, Nav, Footer } from "../components";
 
 export class FormObserver extends NavigatableObserver {
   /**
@@ -12,9 +15,23 @@ export class FormObserver extends NavigatableObserver {
     super(subject, stateContext);
   }
 
+  // since we have 2 suclasses we need to completely overrride this method
+  // render() {
+  //   super.render();
+  //   if (this.active == true) {
+  //     this.addPicOnFormSubmit();
+  //   }
+  // }
+
   render() {
-    super.render();
     if (this.active == true) {
+      document.querySelector("#root").innerHTML = `
+                ${Header(this.stateContext)}
+                ${Nav(this.subject.stateStore.Links)}
+                ${Main(this.stateContext)}
+                ${Footer()}
+            `;
+      super.addNavEventListeners();
       this.addPicOnFormSubmit();
     }
   }
@@ -33,6 +50,9 @@ export class FormObserver extends NavigatableObserver {
           return pictureObject;
         }, {});
         // add new picture to state.Gallery.pictures
+        console.log(
+          `addPicOnFormSubmit: this.subject.stateStore.Gallery.pictures.length = ${this.subject.stateStore.Gallery.pictures.length}`
+        );
         this.subject.stateStore.Gallery.pictures.push(newPic);
         this.subject.setState(this.subject.stateStore.Gallery);
       });

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,5 +1,9 @@
 import { NavigatableObserver } from "./NavigatableObserver";
-
+/**
+ * Another demonstration sub-class, "FormObserver" contains code specific to the form page.
+ * while it is unecessary to break this code out, more complex websites often benefit by
+ * grouping code in more digestable chunks.
+ */
 export class FormObserver extends NavigatableObserver {
   /**
    *
@@ -20,6 +24,9 @@ export class FormObserver extends NavigatableObserver {
     }
   }
 
+  /**
+   * add event listener to add a image to the gallery and then show the gallery.
+   */
   addPicOnFormSubmit() {
     if (this.stateContext.view === "Form") {
       document.querySelector("form").addEventListener("submit", event => {
@@ -34,9 +41,6 @@ export class FormObserver extends NavigatableObserver {
           return pictureObject;
         }, {});
         // add new picture to state.Gallery.pictures
-        console.log(
-          `addPicOnFormSubmit: this.subject.stateStore.Gallery.pictures.length = ${this.subject.stateStore.Gallery.pictures.length}`
-        );
         this.subject.stateStore.Gallery.pictures.push(newPic);
         this.subject.router.navigate("/Gallery"); // we must use this instead of "setState"
       });

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,0 +1,41 @@
+import { NavigatableObserver } from "./NavigatableObserver";
+
+export class FormObserver extends NavigatableObserver {
+  /**
+   *
+   * @param {*} subject is the "observable" that the observer is to observe, often called
+   * observable" or "subject"
+   * @param {*} stateContext state context for this observable declared when instatiated.
+   * Example: state.Gallery from 'import * as state from "../store";'
+   */
+  constructor(subject, stateContext) {
+    super(subject, stateContext);
+  }
+
+  render() {
+    super.render();
+    if (this.active == true) {
+      this.addPicOnFormSubmit();
+    }
+  }
+
+  addPicOnFormSubmit() {
+    if (this.stateContext.view === "Form") {
+      document.querySelector("form").addEventListener("submit", event => {
+        event.preventDefault();
+        // convert HTML elements to Array
+        let inputList = Array.from(event.target.elements);
+        // remove submit button from list
+        inputList.pop();
+        // construct new picture object
+        let newPic = inputList.reduce((pictureObject, input) => {
+          pictureObject[input.name] = input.value;
+          return pictureObject;
+        }, {});
+        // add new picture to state.Gallery.pictures
+        this.subject.stateStore.Gallery.pictures.push(newPic);
+        this.subject.setState(this.subject.stateStore.Gallery);
+      });
+    }
+  }
+}

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -19,6 +19,7 @@ export class FormObserver extends NavigatableObserver {
     super.render();
     if (this.active == true) {
       this.addPicOnFormSubmit();
+      //this.subject.router.updatePageLinks();
     }
   }
 
@@ -53,7 +54,8 @@ export class FormObserver extends NavigatableObserver {
           `addPicOnFormSubmit: this.subject.stateStore.Gallery.pictures.length = ${this.subject.stateStore.Gallery.pictures.length}`
         );
         this.subject.stateStore.Gallery.pictures.push(newPic);
-        this.subject.setState(this.subject.stateStore.Gallery);
+        this.subject.router.navigate("/Gallery");
+        //this.subject.setState(this.subject.stateStore.Gallery);
       });
     }
   }

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,6 +1,5 @@
 "use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
-import { Header, Main, Nav, Footer } from "../components";
 
 export class FormObserver extends NavigatableObserver {
   /**
@@ -19,22 +18,8 @@ export class FormObserver extends NavigatableObserver {
     super.render();
     if (this.active == true) {
       this.addPicOnFormSubmit();
-      //this.subject.router.updatePageLinks();
     }
   }
-
-  // render() {
-  //   if (this.active == true) {
-  //     document.querySelector("#root").innerHTML = `
-  //               ${Header(this.stateContext)}
-  //               ${Nav(this.subject.stateStore.Links)}
-  //               ${Main(this.stateContext)}
-  //               ${Footer()}
-  //           `;
-  //     super.addNavEventListeners();
-  //     this.addPicOnFormSubmit();
-  //   }
-  // }
 
   addPicOnFormSubmit() {
     if (this.stateContext.view === "Form") {
@@ -54,8 +39,7 @@ export class FormObserver extends NavigatableObserver {
           `addPicOnFormSubmit: this.subject.stateStore.Gallery.pictures.length = ${this.subject.stateStore.Gallery.pictures.length}`
         );
         this.subject.stateStore.Gallery.pictures.push(newPic);
-        this.subject.router.navigate("/Gallery");
-        //this.subject.setState(this.subject.stateStore.Gallery);
+        this.subject.router.navigate("/Gallery"); // we must use this instead of "setState"
       });
     }
   }

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,4 +1,3 @@
-"use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
 
 export class FormObserver extends NavigatableObserver {

--- a/lib/FormObserver.js
+++ b/lib/FormObserver.js
@@ -1,6 +1,5 @@
 "use strict";
 import { NavigatableObserver } from "./NavigatableObserver";
-//import * as stateStore from "../store";
 import { Header, Main, Nav, Footer } from "../components";
 
 export class FormObserver extends NavigatableObserver {
@@ -16,25 +15,25 @@ export class FormObserver extends NavigatableObserver {
   }
 
   // since we have 2 suclasses we need to completely overrride this method
-  // render() {
-  //   super.render();
-  //   if (this.active == true) {
-  //     this.addPicOnFormSubmit();
-  //   }
-  // }
-
   render() {
+    super.render();
     if (this.active == true) {
-      document.querySelector("#root").innerHTML = `
-                ${Header(this.stateContext)}
-                ${Nav(this.subject.stateStore.Links)}
-                ${Main(this.stateContext)}
-                ${Footer()}
-            `;
-      super.addNavEventListeners();
       this.addPicOnFormSubmit();
     }
   }
+
+  // render() {
+  //   if (this.active == true) {
+  //     document.querySelector("#root").innerHTML = `
+  //               ${Header(this.stateContext)}
+  //               ${Nav(this.subject.stateStore.Links)}
+  //               ${Main(this.stateContext)}
+  //               ${Footer()}
+  //           `;
+  //     super.addNavEventListeners();
+  //     this.addPicOnFormSubmit();
+  //   }
+  // }
 
   addPicOnFormSubmit() {
     if (this.stateContext.view === "Form") {

--- a/lib/NavigatableObserver.js
+++ b/lib/NavigatableObserver.js
@@ -12,6 +12,7 @@ export class NavigatableObserver extends StateObserver {
     if (this.active == true) {
       super.render();
       this.addNavEventListeners();
+      this.subject.router.updatePageLinks();
     }
   }
 

--- a/lib/NavigatableObserver.js
+++ b/lib/NavigatableObserver.js
@@ -1,3 +1,4 @@
+"use strict";
 import { StateObserver } from "./StateObserver";
 
 export class NavigatableObserver extends StateObserver {

--- a/lib/NavigatableObserver.js
+++ b/lib/NavigatableObserver.js
@@ -1,11 +1,19 @@
 import { StateObserver } from "./StateObserver";
 
+/**
+ * NavigatableObserver is a sub-class of StateObserver that encapsulates the
+ * "addNavEventListeners" method for navigation. It's mostly for demonstration
+ * purposes as "addNavEventListeners" could be included in StateObserver.
+ */
 export class NavigatableObserver extends StateObserver {
   constructor(subject, stateContext) {
     super(subject, stateContext);
     subject.registerObserver(this);
   }
 
+  /**
+   * render content
+   */
   render() {
     // you always need to check to make sure you are rendering an acive view
     if (this.active == true) {
@@ -15,6 +23,9 @@ export class NavigatableObserver extends StateObserver {
     }
   }
 
+  /**
+   * add on click listener to show nav link menu when hidden
+   */
   addNavEventListeners() {
     // add menu toggle to bars icon in nav bar
     document

--- a/lib/NavigatableObserver.js
+++ b/lib/NavigatableObserver.js
@@ -1,4 +1,3 @@
-"use strict";
 import { StateObserver } from "./StateObserver";
 
 export class NavigatableObserver extends StateObserver {

--- a/lib/StateObserver.js
+++ b/lib/StateObserver.js
@@ -1,7 +1,10 @@
-//import * as views from "../components/views";
-"use strict";
 import { Header, Main, Nav, Footer } from "../components";
 
+/**
+ * StateObserver is the base class observer for the StateSubject "observable". It is the
+ * Observer component of the GoF Observer Pattern. When the StateSubject notifies the
+ * SateObserver of a change, it will be processed here, on in a subclass of this class.
+ */
 export class StateObserver {
   constructor(subject, stateContext) {
     this.subject = subject;
@@ -11,15 +14,24 @@ export class StateObserver {
     subject.registerObserver(this);
   }
 
+  /**
+   * Called from the StateSubject notify method
+   * @param {*} state the state we are transitioning to.
+   */
   update(state) {
+    // make sure I'm the appropriate observer to handled this transition
     if (state.view == this.stateContext.view) {
       this.active = true;
       this.render();
     } else {
+      // if not, do nothing, and set active to false
       this.active = false;
     }
   }
 
+  /**
+   * render all changes associated with this transition
+   */
   render() {
     if (this.active == true) {
       document.querySelector("#root").innerHTML = `
@@ -32,6 +44,9 @@ export class StateObserver {
     }
   }
 
+  /**
+   * helper method for simple refreshes not captured/induced by state changes
+   */
   refreshObserver() {
     this.render();
   }

--- a/lib/StateObserver.js
+++ b/lib/StateObserver.js
@@ -1,21 +1,23 @@
-import * as views from "../components/views";
-import { Header, Nav, Footer } from "../components";
+//import * as views from "../components/views";
+"use strict";
+import { Header, Main, Nav, Footer } from "../components";
 
 export class StateObserver {
   constructor(subject, stateContext) {
     this.subject = subject;
     this.stateContext = stateContext;
+    //this.stateContext = Object.assign(this.stateContext, stateContext); //Object.assign(
     this.active = subject.state.view == stateContext.view;
     subject.registerObserver(this);
   }
 
-  notify(state) {
+  update(state) {
     if (state.view == this.stateContext.view) {
       this.active = true;
+      this.render();
     } else {
       this.active = false;
     }
-    this.render();
   }
 
   render() {
@@ -23,7 +25,7 @@ export class StateObserver {
       document.querySelector("#root").innerHTML = `
                 ${Header(this.stateContext)}
                 ${Nav(this.subject.stateStore.Links)}
-                ${views[this.stateContext.view](this.stateContext)}
+                ${Main(this.stateContext)}
                 ${Footer()}
             `;
     }

--- a/lib/StateObserver.js
+++ b/lib/StateObserver.js
@@ -28,6 +28,7 @@ export class StateObserver {
                 ${Main(this.stateContext)}
                 ${Footer()}
             `;
+      this.subject.router.updatePageLinks();
     }
   }
 

--- a/lib/StateObserver.js
+++ b/lib/StateObserver.js
@@ -1,6 +1,5 @@
 import * as views from "../components/views";
 import { Header, Nav, Footer } from "../components";
-import * as stateStore from "../store";
 
 export class StateObserver {
   constructor(subject, stateContext) {
@@ -23,35 +22,14 @@ export class StateObserver {
     if (this.active == true) {
       document.querySelector("#root").innerHTML = `
                 ${Header(this.stateContext)}
-                ${Nav(stateStore.Links)}
+                ${Nav(this.subject.stateStore.Links)}
                 ${views[this.stateContext.view](this.stateContext)}
                 ${Footer()}
             `;
-      this.addPicOnFormSubmit(this.stateContext);
     }
   }
 
   refreshObserver() {
     this.render();
-  }
-
-  addPicOnFormSubmit(st) {
-    if (st.view === "Form") {
-      document.querySelector("form").addEventListener("submit", event => {
-        event.preventDefault();
-        // convert HTML elements to Array
-        let inputList = Array.from(event.target.elements);
-        // remove submit button from list
-        inputList.pop();
-        // construct new picture object
-        let newPic = inputList.reduce((pictureObject, input) => {
-          pictureObject[input.name] = input.value;
-          return pictureObject;
-        }, {});
-        // add new picture to state.Gallery.pictures
-        st.Gallery.pictures.push(newPic);
-        this.subject.setState(st.Gallery);
-      });
-    }
   }
 }

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -1,7 +1,6 @@
-import * as stateStore from "../store";
-
+"use strict";
 export class StateSubject {
-  constructor(state) {
+  constructor(state, stateStore) {
     this.observables = [];
     this.state = state;
     this.stateStore = stateStore;
@@ -13,12 +12,12 @@ export class StateSubject {
 
   setState(state) {
     this.state = state;
-    this.notifyObservers(this.state);
+    this.notify(this.state);
   }
 
-  notifyObservers(state) {
+  notify(state) {
     this.observables.forEach(element => {
-      element.notify(state);
+      element.update(state);
     });
   }
 

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -14,29 +14,51 @@ export class StateSubject {
     this.router = router;
   }
 
+  /**
+   * return the current state
+   */
   getState() {
     return this.state;
   }
 
+  /**
+   * Set the current state and call notify
+   * @param {*} state The state to be updated to
+   */
   setState(state) {
     this.state = state;
     this.notify(this.state);
   }
 
+  /**
+   * Notify all observers that state has changed
+   * @param {*} state The state being updated to
+   */
   notify(state) {
     this.observables.forEach(element => {
       element.update(state);
     });
   }
 
+  /**
+   * register another observer
+   * @param {StateObserver} stateObserver the observer we whish to registar
+   */
   registerObserver(stateObserver) {
     this.observables.push(stateObserver);
   }
 
+  /**
+   * Remove observer from the list of observers, it will no longer get notifications
+   * @param {*} stateObserver the observer to be unregistered, must be exact instance.
+   */
   unregisterObserver(stateObserver) {
     this.observables = this.observables.filter(obs => obs !== stateObserver);
   }
 
+  /**
+   * helper method to refresh views of all observers.
+   */
   refreshStateView() {
     this.observables.forEach(element => {
       element.refreshObserver();

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -1,9 +1,12 @@
-"use strict";
+//"use strict";
+//import * as state from "../store";
 export class StateSubject {
-  constructor(state, stateStore) {
+  constructor(state, stateStore, router) {
+    //state, stateStore) {
     this.observables = [];
     this.state = state;
-    this.stateStore = stateStore;
+    this.stateStore = stateStore; //stateStore;
+    this.router = router;
   }
 
   getState() {

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -1,3 +1,11 @@
+/**
+ * Class "StateSubject" is the base class for the "observable" in the observer pattern.
+ * The "subject" ("observable") contains the state data, when we want to update the state,
+ * we do so via the StateSubject.setState method. The "observers" are coupled to the "subject"
+ * via the "registerObserver". When the state is updated the "subject" calls the "update" method
+ * on all registered "observers". The "observers" process/handle the update.
+ * This is exactly like how event listeners work with the "addEventListener()" method.
+ */
 export class StateSubject {
   constructor(state, stateStore, router) {
     this.observables = [];

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -1,7 +1,10 @@
+import * as stateStore from "../store";
+
 export class StateSubject {
   constructor(state) {
     this.observables = [];
     this.state = state;
+    this.stateStore = stateStore;
   }
 
   getState() {

--- a/lib/StateSubject.js
+++ b/lib/StateSubject.js
@@ -1,11 +1,8 @@
-//"use strict";
-//import * as state from "../store";
 export class StateSubject {
   constructor(state, stateStore, router) {
-    //state, stateStore) {
     this.observables = [];
     this.state = state;
-    this.stateStore = stateStore; //stateStore;
+    this.stateStore = stateStore;
     this.router = router;
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,6 @@
+export { StateSubject } from "./StateSubject";
+export { StateObserver } from "./StateObserver";
+export { NavigatableObserver } from "./NavigatableObserver";
+export { ApiNavigateableObserver } from "./ApiNavigateableObserver";
+export { BlogObserver } from "./BlogObserver";
+export { FormObserver } from "./FormObserver";


### PR DESCRIPTION
this is an example adding the observer pattern to manage state. We separate code into observer sub-classes when there is  functional differences between pages: e.g. pages with forms or pages that require api requests vs static pages. 
I hope this is helpful, I tried to minimize code changes for readability and transparency. 